### PR TITLE
fix: 修复流式数据处理时的数组越界错误（解决发送问候语崩溃问题）

### DIFF
--- a/ShareRibbon/Controls/BaseChatControl.vb
+++ b/ShareRibbon/Controls/BaseChatControl.vb
@@ -1,4 +1,4 @@
-﻿' ShareRibbon\Controls\BaseChatControl.vb
+' ShareRibbon\Controls\BaseChatControl.vb
 Imports System.Diagnostics
 Imports System.Drawing
 Imports System.IO
@@ -4229,13 +4229,20 @@ Public MustInherit Class BaseChatControl
                 }
                 End If
 
-                Dim reasoning_content As String = jsonObj("choices")(0)("delta")("reasoning_content")?.ToString()
+                Dim reasoning_content As String = Nothing
+                If jsonObj("choices") IsNot Nothing AndAlso jsonObj("choices").Count > 0 Then
+                    reasoning_content = jsonObj("choices")(0)("delta")("reasoning_content")?.ToString()
+                End If
+
                 If Not String.IsNullOrEmpty(reasoning_content) Then
                     _currentMarkdownBuffer.Append(reasoning_content)
                     FlushBuffer("reasoning", uuid)
                 End If
 
-                Dim content As String = jsonObj("choices")(0)("delta")("content")?.ToString()
+                Dim content As String = Nothing
+                If jsonObj("choices") IsNot Nothing AndAlso jsonObj("choices").Count > 0 Then
+                    content = jsonObj("choices")(0)("delta")("content")?.ToString()
+                End If
                 'Debug.Print(content)
                 If Not String.IsNullOrEmpty(content) Then
                     'Debug.WriteLine($"[ProcessStreamChunk] 解析到content: {content.Substring(0, Math.Min(50, content.Length))}...")
@@ -4535,7 +4542,10 @@ Public MustInherit Class BaseChatControl
                                                 'Debug.WriteLine($"MCP润色调用tokens: {mcpTokenInfo.Value.TotalTokens}")
                                             End If
 
-                                            Dim content As String = jsonObj("choices")(0)("delta")("content")?.ToString()
+                                            Dim content As String = Nothing
+                                            If jsonObj("choices") IsNot Nothing AndAlso jsonObj("choices").Count > 0 Then
+                                                content = jsonObj("choices")(0)("delta")("content")?.ToString()
+                                            End If
 
                                             If Not String.IsNullOrEmpty(content) Then
                                                 formattedBuilder.Append(content)

--- a/ShareRibbon/Controls/Services/HttpStreamService.vb
+++ b/ShareRibbon/Controls/Services/HttpStreamService.vb
@@ -345,14 +345,21 @@ Public Class HttpStreamService
                     End If
 
                     ' 处理推理内容
-                    Dim reasoning_content As String = jsonObj("choices")(0)("delta")("reasoning_content")?.ToString()
+                    Dim reasoning_content As String = Nothing
+                    If jsonObj("choices") IsNot Nothing AndAlso jsonObj("choices").Count > 0 Then
+                        reasoning_content = jsonObj("choices")(0)("delta")("reasoning_content")?.ToString()
+                    End If
+
                     If Not String.IsNullOrEmpty(reasoning_content) Then
                         _currentMarkdownBuffer.Append(reasoning_content)
                         Await FlushBufferAsync("reasoning", uuid)
                     End If
 
                     ' 处理正文内容
-                    Dim content As String = jsonObj("choices")(0)("delta")("content")?.ToString()
+                    Dim content As String = Nothing
+                    If jsonObj("choices") IsNot Nothing AndAlso jsonObj("choices").Count > 0 Then
+                        content = jsonObj("choices")(0)("delta")("content")?.ToString()
+                    End If
                     If Not String.IsNullOrEmpty(content) Then
                         _currentMarkdownBuffer.Append(content)
                         Await FlushBufferAsync("content", uuid)
@@ -643,7 +650,10 @@ Public Class HttpStreamService
                                                 _stateService.AddTokens(CInt(usage("total_tokens")))
                                             End If
 
-                                            Dim content As String = jsonObj("choices")(0)("delta")("content")?.ToString()
+                                            Dim content As String = Nothing
+                                            If jsonObj("choices") IsNot Nothing AndAlso jsonObj("choices").Count > 0 Then
+                                                content = jsonObj("choices")(0)("delta")("content")?.ToString()
+                                            End If
                                             If Not String.IsNullOrEmpty(content) Then
                                                 formattedBuilder.Append(content)
                                             End If


### PR DESCRIPTION
<img width="388" height="168" alt="image" src="https://github.com/user-attachments/assets/f2b9f79a-f756-4ad4-99d9-42b635e7f046" />
原因分析
该错误的根本原因在于代码在处理 AI 的流式响应数据（Stream Chunks）时，没有充分检查 choices 数组是否存在及其长度。
特定响应格式：某些 AI 模型（或通过代理访问时）在响应的最后一个数据块中仅返回 usage 信息（如 Token 消耗统计），而不包含 choices 数组，或者返回一个空的 choices 数组。
硬编码索引访问：原代码直接尝试访问 jsonObj("choices")(0)。当遇到上述不含 choices 的数据块时，就会触发 ArgumentOutOfRangeException（索引超出范围）异常。
问候语触发频率高：问候语的回复通常非常短且生成迅速，更容易在短时间内收到这种包含统计信息的末尾数据块，从而暴露出该漏洞。
修复方案
我已经在 BaseChatControl.vb 和 HttpStreamService.vb 中对所有流式解析逻辑添加了安全检查：
在访问 choices 数组之前，先验证其是否不为 Nothing 且 Count > 0。
针对推理内容（Reasoning Content）和正文内容（Content）的提取都应用了此安全逻辑。